### PR TITLE
Adding a check to see whether document::stream copy constructor and a…

### DIFF
--- a/include/simdjson/document_stream.h
+++ b/include/simdjson/document_stream.h
@@ -19,21 +19,6 @@ public:
   really_inline ~stream() noexcept;
 
   /**
-   * Take another stream's buffers and state.
-   *
-   * @param other The stream to take. Its capacity is zeroed.
-   */
-  stream(document::stream &&other) = default;
-  stream(const document::stream &) = delete; // Disallow copying
-  /**
-   * Take another stream's buffers and state.
-   *
-   * @param other The stream to take. Its capacity is zeroed.
-   */
-  stream &operator=(document::stream &&other) = default;
-  stream &operator=(const document::stream &) = delete; // Disallow copying
-
-  /**
    * An iterator through a forward-only stream of documents.
    */
   class iterator {
@@ -71,6 +56,11 @@ public:
   really_inline iterator end() noexcept;
 
 private:
+
+  stream &operator=(const document::stream &) = delete; // Disallow copying
+
+  stream(document::stream &other) = delete;    // Disallow copying
+
   really_inline stream(document::parser &parser, const uint8_t *buf, size_t len, size_t batch_size, error_code error = SUCCESS) noexcept;
 
   /**

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -232,6 +232,16 @@ bool stable_test() {
   return newjson == json;
 }
 
+static simdjson::document::stream parse_many_stream_return(simdjson::document::parser &parser, simdjson::padded_string &str) {
+  return parser.parse_many(str);
+}
+// this is a compilation test
+UNUSED static void parse_many_stream_assign() {
+    simdjson::document::parser parser;
+    simdjson::padded_string str("{}",2);
+    simdjson::document::stream s1 = parse_many_stream_return(parser, str);
+}
+
 static bool parse_json_message_issue467(char const* message, std::size_t len, size_t expectedcount) {
     simdjson::document::parser parser;
     size_t count = 0;


### PR DESCRIPTION
…ssignment actually compile (#556)

* Currently, document::stream contains an attribute that is a reference:

```
      document::parser &parser;
```

Yet we try to have it default on the move operator:

```
  stream &operator=(document::stream &&other) = default;
  stream &operator=(const document::stream &) = delete; // Disallow copying
```

```
  stream(document::stream &&other) = default;
  stream(const document::stream &) = delete; // Disallow copying
```

I am not sure what the move is supposed to do with the reference.

I cannot find where we test the copy constructor and assignment. This has been concerned that it is either dead code or buggy code.

* Remove non-working, unnecessary move constructors

* We still want to disallow copies.

Co-authored-by: John Keiser <john@johnkeiser.com>