### PR TITLE
Workaround for SIMDJSON_ASSUME "side-effect" warning under some compi…

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -146,8 +146,12 @@ simdjson_really_inline uint32_t json_iterator::peek_length(token_position positi
 }
 
 simdjson_really_inline token_position json_iterator::last_document_position() const noexcept {
-  SIMDJSON_ASSUME(parser->implementation->n_structural_indexes > 0);
-  return &parser->implementation->structural_indexes[parser->implementation->n_structural_indexes - 1];
+  // The following line fails under some compilers...
+  // SIMDJSON_ASSUME(parser->implementation->n_structural_indexes > 0);
+  // since it has side-effects.
+  uint32_t n_structural_indexes{parser->implementation->n_structural_indexes};
+  SIMDJSON_ASSUME(n_structural_indexes > 0);
+  return &parser->implementation->structural_indexes[n_structural_indexes - 1];
 }
 simdjson_really_inline const uint8_t *json_iterator::peek_last() const noexcept {
   return token.peek(last_document_position());


### PR DESCRIPTION
…lers. (#1456)



Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
