### PR TITLE
Removing a misleading comment in the tests. (#1526)

### DIFF
--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -387,8 +387,6 @@ namespace document_stream_tests {
 #endif
   bool simple_example() {
     std::cout << "Running " << __func__ << std::endl;
-    // The last JSON document is
-    // intentionally truncated.
     auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} [1,2,3]  )"_padded;
     simdjson::dom::parser parser;
     size_t count = 0;


### PR DESCRIPTION

Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
