### PR TITLE
Correcting what seems to be a typo and adding some extra logging. (#1…

### DIFF
--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -125,12 +125,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 


### PR DESCRIPTION
…535)



Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
